### PR TITLE
Correct zoom direction to be analogous to Swing

### DIFF
--- a/src/main/java/org/jfree/chart/fx/interaction/ScrollHandlerFX.java
+++ b/src/main/java/org/jfree/chart/fx/interaction/ScrollHandlerFX.java
@@ -30,7 +30,11 @@
  * (C) Copyright 2014-2021, by Object Refinery Limited and Contributors.
  *
  * Original Author:  David Gilbert (for Object Refinery Limited);
- * Contributor(s):   -;
+ * Contributor(s):   Matthias Noebl (for Cropster GmbH);
+ *
+ * Changes
+ * -------
+ * 03-Aug-2018 : Correct zoom direction to be analogous to Swing (MN);
  *
  */
 
@@ -124,7 +128,7 @@ public class ScrollHandlerFX extends AbstractMouseHandlerFX
             plot.setNotify(false);
             int clicks = (int) e.getDeltaY();
             double zf = 1.0 + this.zoomFactor;
-            if (clicks < 0) {
+            if (clicks > 0) {
                 zf = 1.0 / zf;
             }
             if (canvas.isDomainZoomable()) {


### PR DESCRIPTION
Scrolling up should zoom in, which is the default behaviour. This is also how it works with the Swing version of JFreeChart. I verified this on Windows and Mac that currently zooming works differently to other programs.