### PR TITLE
Work around zoom issues on Linux.

### DIFF
--- a/src/main/java/org/jfree/chart/fx/interaction/ScrollHandlerFX.java
+++ b/src/main/java/org/jfree/chart/fx/interaction/ScrollHandlerFX.java
@@ -113,6 +113,11 @@ public class ScrollHandlerFX extends AbstractMouseHandlerFX
     	if (canvas.getChart() == null) {
     	    return;
     	}
+        int clicks = (int) e.getDeltaY();
+        if (clicks == 0) {
+            // don't zoom on events with no wheel movement (occurs on Linux)
+            return;
+        }
         // don't zoom unless the mouse pointer is in the plot's data area
         ChartRenderingInfo info = canvas.getRenderingInfo();
         PlotRenderingInfo pinfo = info.getPlotInfo();
@@ -122,7 +127,6 @@ public class ScrollHandlerFX extends AbstractMouseHandlerFX
             // do not notify while zooming each axis
             boolean notifyState = plot.isNotify();
             plot.setNotify(false);
-            int clicks = (int) e.getDeltaY();
             double zf = 1.0 + this.zoomFactor;
             if (clicks < 0) {
                 zf = 1.0 / zf;


### PR DESCRIPTION
In Linux, the scroll event is sometimes issued with a `deltaY` of zero.  From experience, this seems to occur as often as events including a `deltaY` value.

The net effect of this, based on how the logic works now, is that zooming in one direction appears to do nothing - as the events cancel each other.  In the other direction zooming occurs twice.

Tested and confirmed working on Linux and Windows using JDK 11.